### PR TITLE
🐛 Producer competition also yields edges.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Improved display for sparse graph data views.
 
+- Fix topology bug: isolated producers with selfing edges are still isolated.
+
 # v0.3.0 Upgrade Blueprint/Components Framework
 
 ## Breaking changes (minor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.x.0
+
+- Producers competition links are reified as edges.
+  - Breaking (minor): `producers.competition`
+    is now split into `.matrix` and `.mask`.
+  - Breaking (minor): producers competition rates
+    cannot be modified anymore outside the edges mask.
+
+- Improved display for sparse graph data views.
+
 # v0.3.0 Upgrade Blueprint/Components Framework
 
 ## Breaking changes (minor)

--- a/src/Topologies/Topologies.jl
+++ b/src/Topologies/Topologies.jl
@@ -321,7 +321,7 @@ function pruned_adjacency_matrix(g::Topology, s::Int, e::Int, t::Int, transpose:
     prn, prm = transpose ? (pre_n_target, pre_n_source) : (pre_n_source, pre_n_target)
     n, m = transpose ? (post_n_target, post_n_source) : (post_n_source, post_n_target)
 
-    # One pass nodes to prepare a pre -> index mapping.
+    # One pass over nodes to prepare a pre -> index mapping.
     (i_map, j_map) = map([(prn, line), (prm, col)]) do (prn, type)
         map = []
         skips = 0

--- a/src/expose_data.jl
+++ b/src/expose_data.jl
@@ -91,7 +91,7 @@ macro expose_data(
     #     Fail with `writefails` in case the rhs value is found to be invalid.
     #
     #   template(function) or template(raw -> <body>)
-    #     Generates a `._template` method for the view if sparse,
+    #     Generates a `._template` field for the view if sparse,
     #     initialized with the given function and useful to check the setindex! accesses.
     #
     #   index(function) or index(raw -> <body>)
@@ -395,13 +395,13 @@ macro expose_data(
         # Pick correct supertype.
 
         Sup = if nodes && write
-            NodesWriteView
+            sparse ? SparseNodesWriteView : NodesWriteView
         elseif edges && write
-            EdgesWriteView
+            sparse ? SparseEdgesWriteView : EdgesWriteView
         elseif nodes
-            NodesView
+            sparse ? SparseNodesView : NodesView
         elseif edges
-            EdgesView
+            sparse ? SparseEdgesView : EdgesView
         else
             throw("Unreachable.")
         end

--- a/test/user/04-exposed_data.jl
+++ b/test/user/04-exposed_data.jl
@@ -2,6 +2,7 @@
 module TestExposedData
 
 using EcologicalNetworksDynamics
+using SparseArrays
 using Test
 
 Value = EcologicalNetworksDynamics.Internal # To make @sysfails work.
@@ -22,10 +23,10 @@ const EN = EcologicalNetworksDynamics
     # Nodes view.
 
     # Access with either indices or labels.
-    @test m.producers.mask[1] == false
-    @test m.producers.mask[:a] == false
-    @test m.producers.mask['a'] == false
-    @test m.producers.mask["a"] == false
+    @test m.producers.mask[3]
+    @test m.producers.mask[:c]
+    @test m.producers.mask['c']
+    @test m.producers.mask["c"]
 
     # Access ranges, masks, etc.
     @test m.producers.mask[2:3] == Bool[0, 1]
@@ -313,7 +314,7 @@ end
         EF,
         "Invalid trophic link labels [:b, :a] ([2, 1]) to write edge data. \
          Valid indices must comply to the following template:\n\
-         4×4 SparseArrays.SparseMatrixCSC{Bool, Int64} with 4 stored entries:\n \
+         4×4 $SparseMatrixCSC{Bool, Int64} with 4 stored entries:\n \
           ⋅  1  1  ⋅\n \
           ⋅  ⋅  1  1\n \
           ⋅  ⋅  ⋅  ⋅\n \
@@ -324,7 +325,7 @@ end
         EF,
         "Invalid trophic link index [2, 2] to write edge data. \
          Valid indices must comply to the following template:\n\
-         4×4 SparseArrays.SparseMatrixCSC{Bool, Int64} with 4 stored entries:\n \
+         4×4 $SparseMatrixCSC{Bool, Int64} with 4 stored entries:\n \
           ⋅  1  1  ⋅\n \
           ⋅  ⋅  1  1\n \
           ⋅  ⋅  ⋅  ⋅\n \

--- a/test/user/code_components/logistic_growth.jl
+++ b/test/user/code_components/logistic_growth.jl
@@ -18,7 +18,7 @@
     m = base + lg
     @test m.r == [0, 0, 0, 1, 1]
     @test m.K == [0, 0, 0, 1, 1]
-    @test m.producers.competition == [
+    @test m.producers.competition.matrix == [
         0 0 0 0 0
         0 0 0 0 0
         0 0 0 0 0
@@ -36,7 +36,7 @@
     m = base + lg
     @test m.r == [0, 0, 0, 1, 1]
     @test m.K == [0, 0, 0, 1, 1]
-    @test m.producers.competition == [
+    @test m.producers.competition.matrix == [
         0 0 0 0 0
         0 0 0 0 0
         0 0 0 0 0

--- a/test/user/data_components/producers_competition.jl
+++ b/test/user/data_components/producers_competition.jl
@@ -14,16 +14,21 @@
         0 2 4
     ])
     m = base + pc
-    @test m.producers.competition == [
+    @test m.producers.competition.matrix == [
         0 0 0
         0 1 3
         0 2 4
+    ]
+    @test m.producers.competition.mask == [
+        0 0 0
+        0 1 1
+        0 1 1
     ]
     @test typeof(pc) === ProducersCompetition.Raw
 
     # Adjacency list.
     m = base + ProducersCompetition([:b => [:b => 1, :c => 3], :c => [:c => 4]])
-    @test m.producers.competition == [
+    @test m.producers.competition.matrix == [
         0 0 0
         0 1 3
         0 0 4
@@ -33,7 +38,7 @@
     # Scalar.
     pc = ProducersCompetition(2)
     m = base + pc
-    @test m.producers.competition == [
+    @test m.producers.competition.matrix == [
         0 0 0
         0 2 2
         0 2 2
@@ -45,7 +50,7 @@
 
     pc = ProducersCompetition(; diag = 1, off = 2)
     m = base + pc
-    @test m.producers.competition == [
+    @test m.producers.competition.matrix == [
         0 0 0
         0 1 2
         0 2 1


### PR DESCRIPTION
This makes it now impossible to edit the rates later in a way that does not comply to original competition template.
To make it clearer, upgrade graph view displays so their sparsity become obvious.

Fixes #180.